### PR TITLE
Added support for arbitrary config and handlers locations

### DIFF
--- a/AWSSQSAlert/__init__.py
+++ b/AWSSQSAlert/__init__.py
@@ -33,7 +33,15 @@ class AWSSQSAlert:
             self.config['AWS_SECRET'] = None
             
         sys.path.append(os.path.dirname(os.path.realpath(__file__)) + '/handlers')
-        sys.path.append('/etc/aws-sqs-alert/handlers')
+        if hasattr(self.config, 'handlers_dir'):
+            sys.path.append(self.config['handlers_dir'])
+        else:
+            conf_prefix = '/'
+            # Virtualenv
+            if hasattr(sys, 'real_prefix'):
+                conf_prefix = sys.prefix
+            sys.path.append(
+                os.path.join(conf_prefix, 'etc/aws-sqs-alert/handlers'))
 
         autoscale_alert_handlers = self.config['active_handlers']
         handlers = []

--- a/bin/aws-sqs-alert
+++ b/bin/aws-sqs-alert
@@ -1,15 +1,16 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 AWS Minions - Autoscale Alerting
 
 Usage:
-aws-sqs-alert [--AWS_ACCESS=ACCESS_KEY] [--AWS_SECRET=SECRET_KEY] [--debug] [--region=<region>] [<queue>]
+aws-sqs-alert [--AWS_ACCESS=ACCESS_KEY] [--AWS_SECRET=SECRET_KEY] [--debug] [--config=<config_file>] [--region=<region>] [<queue>]
 
 Options:
 -h --help  Show this screen.
 --version  Show version.
 --debug  Turn on Debug Logging
 --region=<region>  AWS Region [default: us-east-1]
+--config=<config_file> Alternative config file location
 <queue>  SQS Queue Name *NOT* ARN
 """
 import time
@@ -29,10 +30,24 @@ from pprint import pprint
 
 if __name__ == '__main__':
 
+    args = docopt(__doc__, options_first=True)
+
+    # Detect is we're working inside a virualenv
+    conf_prefix = '/'
+    if hasattr(sys, 'real_prefix'):
+        conf_prefix = sys.prefix
+
+    config_file = args['--config']
+    if not config_file:
+        config_file = os.path.join(conf_prefix, 'etc/aws-sqs-alert/config.json')
+
     try:
-        config = json.load(open('/etc/aws-sqs-alert/config.json'))
+        config = json.load(open(config_file, 'r'))
     except:
-        raise Exception("Please setup your config.json by copying /etc/aws-sqs-alert/sampleconfig.json to /etc/aws-sqs-alert/config.json and editing.")
+        raise Exception(
+            "Please setup your config file by copying %s to %s and editing." % (
+                os.path.join(conf_prefix, "etc/aws-sqs-alert/sampleconfig.json"),
+                config_file))
     
     logger      = logging.getLogger('autoscale-alert')
     log_handler = logging.handlers.RotatingFileHandler(config['log'], mode='a', maxBytes=104857600, backupCount=10)
@@ -46,8 +61,6 @@ if __name__ == '__main__':
     logger.setLevel(logging.INFO)
     logger.addHandler(log_handler)
     
-    args = docopt(__doc__, options_first=True)
-
     if config['log_level'].upper() == 'DEBUG':
         logger.setLevel(logging.DEBUG)
         stream_handler.setLevel(logging.DEBUG)

--- a/setup.py
+++ b/setup.py
@@ -26,10 +26,20 @@ if sys.version_info <= (2, 4):
 data_files = [('share/aws-sqs-alert', ['LICENSE.txt', 'README.md', 'CHANGES.txt'])]
 distro = platform.dist()[0]
 distro_major_version = platform.dist()[1].split('.')[0]
-data_files.append(('/etc/aws-sqs-alert', ['sampleconfig.json']))
-data_files.append(('/etc/aws-sqs-alert/handlers', ['README.md']))
-data_files.append(('/etc/init.d', ['bin/init.d/aws-sqs-alert']))
-    
+
+# Detect is we're working inside a virualenv
+# http://stackoverflow.com/a/1883251/4843840
+conf_prefix = '/'
+if hasattr(sys, 'real_prefix'):
+    conf_prefix = sys.prefix
+
+data_files.append(
+    (os.path.join(conf_prefix, 'etc/aws-sqs-alert'), ['sampleconfig.json']))
+data_files.append(
+    (os.path.join(conf_prefix, 'etc/aws-sqs-alert/handlers'), ['README.md']))
+data_files.append(
+    (os.path.join(conf_prefix, 'etc/init.d'), ['bin/init.d/aws-sqs-alert']))
+
 def readme():
     with open("README.md") as f:
         return f.read()
@@ -45,7 +55,7 @@ setup(name = "aws-sqs-alert",
       packages = ["AWSSQSAlert", "AWSSQSAlert.handlers", "AWSSQSAlert.test"],
       package_data = {},
       data_files=data_files,
-      install_requires=['boto', 'logstash_formatter', 'statsd'],
+      install_requires=['boto', 'logstash_formatter', 'statsd', 'docopt'],
       license = "GPLv2",
       platforms = "Posix; MacOS X; Windows",
       classifiers = ["Intended Audience :: Developers",


### PR DESCRIPTION
This PR introduces the following changes:

- non-default config file location using `--config` command line option
- non-default handlers location using `handlers_dir` config option
- when the module installed into a virtualenv, files that were installed into `/etc/` are installed into `${VIRTUALENV}/etc/` and expected to be found in that directory (issue #1)
- `docopt` was not included into the setup requirements